### PR TITLE
shiftdhd_pbci function header fix

### DIFF
--- a/R/shift_function_calc.R
+++ b/R/shift_function_calc.R
@@ -413,8 +413,8 @@ shifthd_pbci <- function(data = df,
 
 #' Shift function for two depend groups (pbci method)
 #'
-#' \code{shiftdhd_pbci} returns a shift function for two independent groups or
-#' multiple shift functions for pairs of independent groups. It uses the
+#' \code{shiftdhd_pbci} returns a shift function for two dependent groups or
+#' multiple shift functions for pairs of dependent groups. It uses the
 #' Harrell-Davis quantile estimator in conjunction with a percentile
 #' bootstrap approach.
 #' Unlike \code{\link{shiftdhd}}: \itemize{


### PR DESCRIPTION
If `shiftdhd_pbci`is meant to compare dependent groups, then the current [description](https://rdrr.io/github/GRousselet/rogme/man/shiftdhd_pbci.html) is not consistent.  I guess this is the source that renders the respective doc. 